### PR TITLE
Duplicate Menu Items With Its Module Assignment Option

### DIFF
--- a/en-GB.plg_content_jt_copymoduleassignments.ini
+++ b/en-GB.plg_content_jt_copymoduleassignments.ini
@@ -1,0 +1,9 @@
+ ; @package     jt_copymoduleassignments Joomla.Plugin
+ ; @copyright   Copyright (C) http://www.joomlatema.net, Inc. All rights reserved.
+ ; @license		http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL
+ ; @author     	JoomlaTema.Net
+ ; @link 		http://www.joomlatema.net
+ ; Note : All ini files need to be saved as UTF-8
+
+PLG_JT_COPY_MODULE_ASSIGNMENTS="Content - JT Copy Module Assignments"
+PLG_JT_COPY_MODULE_ASSIGNMENTS_XML_DESCRIPTION="When option Save as Copy is used on a menu item, all the assigned modules will be copied to the new item as well."

--- a/jt_copymoduleassignments.php
+++ b/jt_copymoduleassignments.php
@@ -1,0 +1,84 @@
+<?php
+/***
+ * @package     jt_copymoduleassignments Joomla.Plugin
+ * @copyright   Copyright (C) http://www.joomlatema.net, Inc. All rights reserved.
+ * @license		http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL
+ * @author     	JoomlaTema.Net
+ * @link 		http://www.joomlatema.net
+ ***/
+defined('_JEXEC') or die;
+
+/**
+ * Copy Module Assignments Plugin
+ */
+class PlgContentJt_Copymoduleassignments extends JPlugin
+{
+    protected $db;
+
+    public function __construct($app, $plugin)
+    {
+        parent::__construct($app, $plugin);
+        $this->db = JFactory::getDbo();
+    }
+
+  public function onContentAfterSave($context, &$table, $isNew)
+{
+    // Debugging output
+    JFactory::getApplication()->enqueueMessage('Context: ' . $context);
+    JFactory::getApplication()->enqueueMessage('Is New: ' . ($isNew ? 'Yes' : 'No'));
+
+    // Return if invalid context
+    if ($context != 'com_menus.item') {
+        JFactory::getApplication()->enqueueMessage('Invalid context, exiting.', 'error');
+        return true;
+    }
+
+    // Only proceed if the item is new
+    if ($isNew) {
+        // Get the original menu item ID from the submitted data (this assumes the ID is part of the submitted form data)
+        $originalMenuId = JFactory::getApplication()->input->getInt('id', 0);
+
+        // Debugging output
+        JFactory::getApplication()->enqueueMessage('New Menu Item ID: ' . $table->id);
+        JFactory::getApplication()->enqueueMessage('Original Menu ID: ' . $originalMenuId);
+
+        // Proceed with fetching assigned modules for the original menu ID
+        $query1 = $this->db->getQuery(true)
+            ->select($this->db->quoteName('moduleid'))
+            ->from($this->db->quoteName('#__modules_menu'))
+            ->where($this->db->quoteName('menuid') . ' = ' . (int) $originalMenuId);
+        $this->db->setQuery($query1);
+
+        try {
+            $modules = (array) $this->db->loadColumn();
+            JFactory::getApplication()->enqueueMessage('Modules Found: ' . count($modules));
+        } catch (Exception $e) {
+            JFactory::getApplication()->enqueueMessage('Error fetching modules: ' . $e->getMessage(), 'error');
+            return false;
+        }
+
+        // Assign all found modules to copied menu item
+        if (!empty($modules)) {
+            foreach ($modules as $mid) {
+                $mdl = new stdClass();
+                $mdl->moduleid = $mid;
+                $mdl->menuid = $table->id; // This is the new menu item ID
+                try {
+                    $this->db->insertObject('#__modules_menu', $mdl);
+                    JFactory::getApplication()->enqueueMessage('Assigned module ID: ' . $mid . ' to new menu item ID: ' . $table->id);
+                } catch (Exception $e) {
+                    JFactory::getApplication()->enqueueMessage('Error assigning module ID ' . $mid . ': ' . $e->getMessage(), 'error');
+                }
+            }
+        } else {
+            JFactory::getApplication()->enqueueMessage('No modules to assign', 'warning');
+        }
+
+        // Continue with any additional logic for exception modules if needed...
+    } else {
+        JFactory::getApplication()->enqueueMessage('Item is being edited, not duplicating.', 'warning');
+    }
+
+    return true;
+}
+}

--- a/jt_copymoduleassignments.php
+++ b/jt_copymoduleassignments.php
@@ -1,84 +1,85 @@
 <?php
-/***
+/**
  * @package     jt_copymoduleassignments Joomla.Plugin
- * @copyright   Copyright (C) http://www.joomlatema.net, Inc. All rights reserved.
- * @license		http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL
- * @author     	JoomlaTema.Net
- * @link 		http://www.joomlatema.net
- ***/
+ * @copyright   Copyright (C) http://www.joomlatema.net, Inc.
+ * @license     http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL
+ * @author      JoomlaTema.Net
+ * @link        http://www.joomlatema.net
+ */
+
 defined('_JEXEC') or die;
+
+use Joomla\CMS\Plugin\CMSPlugin;
+use Joomla\CMS\Factory;
+use Joomla\Database\DatabaseInterface;
 
 /**
  * Copy Module Assignments Plugin
  */
-class PlgContentJt_Copymoduleassignments extends JPlugin
+class PlgContentJt_Copymoduleassignments extends CMSPlugin
 {
-    protected $db;
-
-    public function __construct($app, $plugin)
+    public function onContentAfterSave($context, &$table, $isNew)
     {
-        parent::__construct($app, $plugin);
-        $this->db = JFactory::getDbo();
-    }
-
-  public function onContentAfterSave($context, &$table, $isNew)
-{
-    // Debugging output
-    JFactory::getApplication()->enqueueMessage('Context: ' . $context);
-    JFactory::getApplication()->enqueueMessage('Is New: ' . ($isNew ? 'Yes' : 'No'));
-
-    // Return if invalid context
-    if ($context != 'com_menus.item') {
-        JFactory::getApplication()->enqueueMessage('Invalid context, exiting.', 'error');
-        return true;
-    }
-
-    // Only proceed if the item is new
-    if ($isNew) {
-        // Get the original menu item ID from the submitted data (this assumes the ID is part of the submitted form data)
-        $originalMenuId = JFactory::getApplication()->input->getInt('id', 0);
+        $app = Factory::getApplication();
+        $db = Factory::getContainer()->get(DatabaseInterface::class); // Get database instance
 
         // Debugging output
-        JFactory::getApplication()->enqueueMessage('New Menu Item ID: ' . $table->id);
-        JFactory::getApplication()->enqueueMessage('Original Menu ID: ' . $originalMenuId);
+        $app->enqueueMessage('Context: ' . $context);
+        $app->enqueueMessage('Is New: ' . ($isNew ? 'Yes' : 'No'));
 
-        // Proceed with fetching assigned modules for the original menu ID
-        $query1 = $this->db->getQuery(true)
-            ->select($this->db->quoteName('moduleid'))
-            ->from($this->db->quoteName('#__modules_menu'))
-            ->where($this->db->quoteName('menuid') . ' = ' . (int) $originalMenuId);
-        $this->db->setQuery($query1);
-
-        try {
-            $modules = (array) $this->db->loadColumn();
-            JFactory::getApplication()->enqueueMessage('Modules Found: ' . count($modules));
-        } catch (Exception $e) {
-            JFactory::getApplication()->enqueueMessage('Error fetching modules: ' . $e->getMessage(), 'error');
-            return false;
+        // Return if invalid context
+        if ($context !== 'com_menus.item') {
+            $app->enqueueMessage('Invalid context, exiting.', 'error');
+            return true;
         }
 
-        // Assign all found modules to copied menu item
-        if (!empty($modules)) {
-            foreach ($modules as $mid) {
-                $mdl = new stdClass();
-                $mdl->moduleid = $mid;
-                $mdl->menuid = $table->id; // This is the new menu item ID
-                try {
-                    $this->db->insertObject('#__modules_menu', $mdl);
-                    JFactory::getApplication()->enqueueMessage('Assigned module ID: ' . $mid . ' to new menu item ID: ' . $table->id);
-                } catch (Exception $e) {
-                    JFactory::getApplication()->enqueueMessage('Error assigning module ID ' . $mid . ': ' . $e->getMessage(), 'error');
+        // Only proceed if the item is new
+        if ($isNew) {
+            // Get the original menu item ID from the submitted data
+            $originalMenuId = $app->input->getInt('id', 0);
+
+            // Debugging output
+            $app->enqueueMessage('New Menu Item ID: ' . $table->id);
+            $app->enqueueMessage('Original Menu ID: ' . $originalMenuId);
+
+            // Fetch assigned modules for the original menu ID
+            $query = $db->getQuery(true)
+                ->select($db->quoteName('moduleid'))
+                ->from($db->quoteName('#__modules_menu'))
+                ->where($db->quoteName('menuid') . ' = ' . (int) $originalMenuId);
+
+            $db->setQuery($query);
+
+            try {
+                $modules = (array) $db->loadColumn();
+                $app->enqueueMessage('Modules Found: ' . count($modules));
+            } catch (\Exception $e) {
+                $app->enqueueMessage('Error fetching modules: ' . $e->getMessage(), 'error');
+                return false;
+            }
+
+            // Assign all found modules to copied menu item
+            if (!empty($modules)) {
+                foreach ($modules as $mid) {
+                    $mdl = (object) [
+                        'moduleid' => $mid,
+                        'menuid'   => $table->id
+                    ];
+
+                    try {
+                        $db->insertObject('#__modules_menu', $mdl);
+                        $app->enqueueMessage('Assigned module ID: ' . $mid . ' to new menu item ID: ' . $table->id);
+                    } catch (\Exception $e) {
+                        $app->enqueueMessage('Error assigning module ID ' . $mid . ': ' . $e->getMessage(), 'error');
+                    }
                 }
+            } else {
+                $app->enqueueMessage('No modules to assign', 'warning');
             }
         } else {
-            JFactory::getApplication()->enqueueMessage('No modules to assign', 'warning');
+            $app->enqueueMessage('Item is being edited, not duplicating.', 'warning');
         }
 
-        // Continue with any additional logic for exception modules if needed...
-    } else {
-        JFactory::getApplication()->enqueueMessage('Item is being edited, not duplicating.', 'warning');
+        return true;
     }
-
-    return true;
-}
 }

--- a/jt_copymoduleassignments.xml
+++ b/jt_copymoduleassignments.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<extension type="plugin" group="content" method="upgrade">
+ <name>plg_content_jt_copymoduleassignments</name>
+     <author>Joomlatema.net</author>
+	<creationDate>Sep 2024</creationDate>
+    <copyright>JOOMLATEMA.NET</copyright>
+	<license>GPLv3 http://www.gnu.org/licenses/gpl-3.0.html</license>
+    <authorEmail>admin@joomlatema.net</authorEmail>
+   <authorUrl>http://www.joomlatema.net</authorUrl>
+    <version>1.0</version>
+    <description>PLG_JT_COPY_MODULE_ASSIGNMENTS_XML_DESCRIPTION</description>
+    <files>
+        <filename plugin="jt_copymoduleassignments">jt_copymoduleassignments.php</filename>
+		<folder>language</folder>
+    </files>
+    <languages>
+        <language tag="en-GB">language/en-GB.plg_content_jt_copymoduleassignments.ini</language>
+        <language tag="en-GB">language/en-GB.plg_content_jt_copymoduleassignments.sys.ini</language>
+    </languages>
+    <config>
+    </config>
+</extension>


### PR DESCRIPTION
Pull Request for Duplicate Menu Items With Its Module Assignment Option.

### Duplicate Menu Items With Its Module Assignment Option

### When duplicating a menu item with save as copy button, an option to automatically copy all assigned modules to the newly created menu item can be added. A checkbox, such as "Duplicate with all assigned modules," could be included when using the "Save as Copy" button. This ensures seamless duplication while maintaining consistent module assignments.



### Currently the menu item is being duplicated without modules assigned that menu item.


### The newly created menu item optionally will be duplicated by all of its module assignments 



### Link to documentations
A plugin created for this is here: https://extensions.joomla.org/extension/jt-copy-module-assignments/
